### PR TITLE
Support PageUp and PageDown for prev and next in image viewer

### DIFF
--- a/js/ui/imagesViewer.js
+++ b/js/ui/imagesViewer.js
@@ -616,7 +616,13 @@ var slideshowid;
                 if (e.keyCode === 37 && slideshowid && !e.altKey && !e.ctrlKey) {
                     slideshow_prev();
                 }
+                else if (e.keyCode === 33 && slideshowid) { // PageUp
+                    slideshow_prev();
+                }
                 else if (e.keyCode === 39 && slideshowid) {
+                    slideshow_next();
+                }
+                else if (e.keyCode === 34 && slideshowid) { // PageDown
                     slideshow_next();
                 }
                 else if (e.keyCode === 46 && fullScreenManager) {


### PR DESCRIPTION
PageUp and PageDown are commonly used for navigating image viewers. Also, presentation remotes often use these keycodes for "next" and "previous". This small change adds support for these keys to webclients image viewer.