### PR TITLE
Fix format error

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Secure Boot
 and verifies its authenticity by checking the cryptographic hash.
 
 **Note:** This is not the exact same ``secureboot.js`` as we have
-  online at https://mega.nz/``secureboot.js``. We have an automatic
+  online at ``https://mega.nz/secureboot.js``. We have an automatic
   process that generates ``secureboot.js`` with its cryptographic
   hashes and all the versioned resource files
   (``file_X.js``/``file_X.html``) as needed based on this repository


### PR DESCRIPTION
Using
```
https://mega.nz/``secureboot.js``
```
won't help to highlight the text `secureboot.js`, but return 404 when clicking on that link. It should be
```
``https://mega.nz/secureboot.js``
```
or
```
[``secureboot.js``](https://mega.nz/secureboot.js)
```

Thanks!