### PR TITLE
Add DD.MM.YYYY date format option (fixes #137)

### DIFF
--- a/html/fm.html
+++ b/html/fm.html
@@ -3663,6 +3663,12 @@
                                         </div>
                                         <div class="radio-txt">[$19929]</div>
                                     </div>
+                                    <div class="label-wrap align-top">
+                                        <div class="uidateformat radioOff" id="rad18_div">
+                                            <input type="radio" id="rad18" class="uidateformat radioOff" value="2">
+                                        </div>
+                                        <div class="radio-txt">[$25082]</div>
+                                    </div>
                                 </div>
                             </div>
                             <!-- Lets hide this for now -->

--- a/js/utils/locale.js
+++ b/js/utils/locale.js
@@ -285,6 +285,10 @@ function setDateTimeFormat(locales, format) {
  *       14: 2021 (Only year)
  *       15: dd mm (Date format with short month and without time and year)
  *       16: dd (Only day)
+ *
+ * Note: When `fmconfig.uidateformat` is `2`, short date formats (0, 1) are rendered
+ *       as dd.mm.yyyy (or dd.mm.yyyy hh:mm) regardless of locale, the same way
+ *       `uidateformat === 1` forces the ISO yyyy-mm-dd rendering.
  */
 function time2date(unixTime, format) {
     'use strict';
@@ -310,10 +314,22 @@ function time2date(unixTime, format) {
         return isodate.toISOString().replace('T', ' ').substr(0, length);
     };
 
+    // print time as dd.mm.yyyy (or dd.mm.yyyy hh:mm) date format
+    var printDMY = function _printDMY() {
+        var isodate = printISO();
+        var datePart = isodate.substr(0, 10).split('-');
+        var dmy = datePart[2] + '.' + datePart[1] + '.' + datePart[0];
+
+        return format === 0 ? dmy + isodate.substr(10) : dmy;
+    };
+
     dateFunc = dFObj === 'ISO' ? printISO : dFObj.format;
 
-    // if it is short date format and user selected to use ISO format
-    if ((fmconfig.uidateformat || countryAndLocales.country === 'ISO') && format < 2) {
+    // if it is short date format and user selected to use ISO or DD.MM.YYYY format
+    if (format < 2 && fmconfig.uidateformat === 2) {
+        result = printDMY();
+    }
+    else if ((fmconfig.uidateformat || countryAndLocales.country === 'ISO') && format < 2) {
         result = printISO();
     }
     else {

--- a/lang/en_prod.json
+++ b/lang/en_prod.json
@@ -2613,6 +2613,7 @@
     "25049": "Payment failed",
     "25050": "Unfortunately, the payment did not go through. If you believe that this is an error on MEGA\u2019s part, please contact support at [A]https://mega.nz/support[/A]",
     "25081": "Thanks. Your account upgrade will be applied in the next few minutes.\nIf this is a new account and you haven\u2019t verified your email address yet, please do this now.",
+    "25082": "Use the day, month, year format (DD.MM.YYYY)",
     "about_no_vacancies_available": "No vacancies available currently.",
     "about_our_promise_title": "Our promise",
     "ac_closure_email_sent_msg": "An email was sent to %s with a link to close your account.",


### PR DESCRIPTION
Fixes #137

Adds a third date format option in Settings → Preferences → Date and time format: "Use the day, month, year format (DD.MM.YYYY)".

Changes:
- html/fm.html: added third radio option (value=2)
- js/utils/locale.js: added printDMY() helper, wired into time2date() when fmconfig.uidateformat === 2
- lang/en_prod.json: added new locale string

Tested locally on a real account — Date added/Last modified columns correctly render as dd.mm.yyyy (e.g. 30.06.2026 16:01) when the new option is selected. Backward compatible — existing options (locale-based / ISO) unaffected.

Here's the screenshot of the change:
<img width="841" height="203" alt="Screenshot 2026-06-30 160830" src="https://github.com/user-attachments/assets/d349474b-153f-4cd0-ad00-c4c1e3fc90b3" />
